### PR TITLE
Fix crash when update metadata lacks valid version

### DIFF
--- a/packages/plugin-essentials/sources/commands/install.test.ts
+++ b/packages/plugin-essentials/sources/commands/install.test.ts
@@ -1,0 +1,19 @@
+import {isVersionUpdate} from './install';
+
+describe(`isVersionUpdate`, () => {
+  it(`returns false for null candidate`, () => {
+    expect(isVersionUpdate(null, `1.0.0`)).toBe(false);
+  });
+
+  it(`returns false for invalid semver`, () => {
+    expect(isVersionUpdate(`not-a-version`, `1.0.0`)).toBe(false);
+  });
+
+  it(`returns false when candidate is not greater`, () => {
+    expect(isVersionUpdate(`1.0.0`, `1.0.0`)).toBe(false);
+  });
+
+  it(`returns true when candidate is greater`, () => {
+    expect(isVersionUpdate(`1.0.1`, `1.0.0`)).toBe(true);
+  });
+});

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -7,6 +7,10 @@ import {Command, Option, Usage, UsageError}                                     
 import semver                                                                                                                                                                                                             from 'semver';
 import * as t                                                                                                                                                                                                             from 'typanion';
 
+export function isVersionUpdate(candidate: string | null | undefined, current: string) {
+  return !!candidate && !!semver.valid(candidate) && semver.gt(candidate, current);
+}
+
 const LOCKFILE_MIGRATION_RULES: Array<{
   selector: (version: number) => boolean;
   name: keyof ConfigurationValueMap;
@@ -256,7 +260,7 @@ export default class YarnCommand extends BaseCommand {
               const releaseType = isRcBinary ? `canary` : `stable`;
               const candidate = data.latest[releaseType];
 
-              if (semver.gt(candidate, YarnVersion)) {
+              if (isVersionUpdate(candidate, YarnVersion)) {
                 newVersion = [releaseType, candidate];
               }
             }

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -6,7 +6,7 @@ import {Command, Option, Usage, UsageError}                                     
 import semver                                                                                 from 'semver';
 
 export type Tags = {
-  latest: Record<string, string>;
+  latest: Record<string, string | null>;
   tags: Array<string>;
 };
 


### PR DESCRIPTION
## Summary
- relax `Tags` type to allow nullable release entries
- add helper to validate release candidate versions
- guard automatic update check against invalid entries
- test helper behavior

## Testing
- `yarn test:lint`
- `yarn test:unit`
