### PR TITLE
Add catalog dependency resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features in `master` can be tried out by running `yarn set version from sources`
 - `node-modules` linker supports hoisting into inner workspaces that are parents of other workspaces
 - `node-modules` linker attemps to hoist tree more exhaustivel until nothing can be hoisted
 - `node-modules` linker uses aggregated count of peer and regular usages to decide hoisting priority, instead of preferring peer usages over regular as before, which should result in fewer duplicates
+- Added `dependencyCatalogs` configuration and the `catalog:` protocol for shared dependency versions.
 
 ## 4.1.0
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/catalog.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/catalog.test.ts
@@ -1,0 +1,64 @@
+/* eslint @stylistic/quotes: 0 */
+describe(`Protocols`, () => {
+  describe(`catalog:`, () => {
+    test(
+      `it should resolve via default catalog`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `catalog:`},
+        },
+        {dependencyCatalogs: {default: {"no-deps": "1.0.0"}}},
+        async ({run, source}) => {
+          await run(`install`);
+          await expect(source(`require(\`no-deps/package.json\`)`)).resolves.toMatchObject({
+            name: `no-deps`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should resolve via named catalog`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `catalog:foo`},
+        },
+        {dependencyCatalogs: {foo: {"no-deps": "1.0.0"}}},
+        async ({run, source}) => {
+          await run(`install`);
+          await expect(source(`require(\`no-deps/package.json\`)`)).resolves.toMatchObject({
+            name: `no-deps`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should fail if the catalog doesn't exist`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `catalog:missing`},
+        },
+        {},
+        async ({run}) => {
+          await expect(run(`install`)).rejects.toThrow(/YN0092/);
+        },
+      ),
+    );
+
+    test(
+      `it should fail if the entry doesn't exist`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `catalog:`},
+        },
+        {dependencyCatalogs: {default: {}}},
+        async ({run}) => {
+          await expect(run(`install`)).rejects.toThrow(/YN0093/);
+        },
+      ),
+    );
+  });
+});

--- a/packages/docusaurus/docs/advanced/01-general-reference/protocols/catalog.mdx
+++ b/packages/docusaurus/docs/advanced/01-general-reference/protocols/catalog.mdx
@@ -1,0 +1,30 @@
+---
+category: protocols
+slug: /protocol/catalog
+title: "Catalog Protocol"
+description: Resolve versions from dependency catalogs.
+---
+
+The `catalog:` protocol lets you replace hard coded ranges with values read from a shared catalog defined in your `.yarnrc.yml` file.
+
+```yaml
+dependencyCatalogs:
+  default:
+    react: "^18.2.0"
+    lodash: "^4.17.21"
+  legacy:
+    react: "^17.0.0"
+```
+
+Using the catalog is as simple as referencing it in your manifest:
+
+```json
+{
+  "dependencies": {
+    "react": "catalog:",
+    "lodash": "catalog:legacy"
+  }
+}
+```
+
+During resolution the ranges will be replaced by the values from the catalog.

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -7,11 +7,9 @@
     "1) Hosted on the Yarn Website at http://yarnpkg.com/configuration/yarnrc.json",
     "2) Registered on the SchemaStore catalog so that editors can offer autocompletion and validation.",
     "3) Used to generate the documentation page at http://yarnpkg.com/configuration/yarnrc",
-
     "Note: Properties prefixed with a single underscore (e.g. _exampleItems, _exampleKeys)",
     "are unique to our documentation generation interpreter. All others will be picked up",
     "by most JSON schema interpreters.",
-
     "Rules:",
     "1) Don't set a default if it's null, dynamic, or an object.",
     "2) Use `examples` for scalars, `_exampleItems` for arrays, and `_exampleKeys` for objects.",
@@ -32,7 +30,11 @@
       "type": "string",
       "title": "Behavior that Yarn should follow when it detects that a cache entry is outdated.",
       "description": "Whether or not a cache entry is outdated depends on whether it has been built and checksumed by an earlier release of Yarn, or under a different compression settings. Possible behaviors are:\n\n- If `required-only`, it'll keep using the file as-is, unless the version that generated it was decidedly too old.\n- If `match-spec`, it'll also rebuild the file if the compression level has changed.\n- If `always` (the default), it'll always regenerate the cache files so they use the current cache version.",
-      "enum": ["required-only", "match-spec", "always"],
+      "enum": [
+        "required-only",
+        "match-spec",
+        "always"
+      ],
       "default": "always"
     },
     "changesetBaseRefs": {
@@ -43,7 +45,14 @@
       "items": {
         "type": "string"
       },
-      "default": ["master", "origin/master", "upstream/master", "main", "origin/main", "upstream/main"]
+      "default": [
+        "master",
+        "origin/master",
+        "upstream/master",
+        "main",
+        "origin/main",
+        "upstream/main"
+      ]
     },
     "changesetIgnorePatterns": {
       "_package": "@yarnpkg/plugin-git",
@@ -54,14 +63,21 @@
         "type": "string"
       },
       "default": [],
-      "_exampleItems": ["**/*.test.{js,ts}"]
+      "_exampleItems": [
+        "**/*.test.{js,ts}"
+      ]
     },
     "checksumBehavior": {
       "_package": "@yarnpkg/core",
       "type": "string",
       "title": "Behavior that Yarn should follow when it detects that a cache entry has a different checksum than expected.",
       "description": "Possible behaviors are:\n\n- If `throw` (the default), Yarn will throw an exception.\n- If `update`, the lockfile will be updated to match the cached checksum.\n- If `reset`, the cache entry will be purged and fetched anew.\n- If `ignore`, nothing will happen, Yarn will skip the check.",
-      "enum": ["throw", "update", "ignore", "reset"],
+      "enum": [
+        "throw",
+        "update",
+        "ignore",
+        "reset"
+      ],
       "default": "throw"
     },
     "cloneConcurrency": {
@@ -73,10 +89,25 @@
     },
     "compressionLevel": {
       "_package": "@yarnpkg/core",
-      "type": ["number", "string"],
+      "type": [
+        "number",
+        "string"
+      ],
       "title": "Compression level employed for zip archives",
       "description": "Possible values go from `0` (\"no compression, faster\") to `9` (\"heavy compression, slower\"). The value `mixed` is a variant of `9` where files are stored uncompressed if the gzip overhead would exceed the size gain.\n\nThe default is `0`, which tends to be significantly faster to install. Projects using zero-installs are advised to keep it this way, as experiments showed that Git stores uncompressed package archives more efficiently than gzip-compressed ones.",
-      "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, "mixed"],
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        "mixed"
+      ],
       "default": "mixed"
     },
     "constraintsPath": {
@@ -106,7 +137,11 @@
       "type": "string",
       "title": "Default prefix used in semver ranges created by `yarn add` and similar commands.",
       "description": "Possible values are `\"^\"` (the default), `\"~\"` or `\"\"`.",
-      "enum": ["^", "~", ""],
+      "enum": [
+        "^",
+        "~",
+        ""
+      ],
       "default": "^"
     },
     "deferredVersionFolder": {
@@ -116,19 +151,49 @@
       "format": "uri-reference",
       "default": "./.yarn/versions"
     },
+    "dependencyCatalogs": {
+      "_package": "@yarnpkg/core",
+      "title": "Custom dependency version catalogs used by the catalog: protocol.",
+      "description": "Mapping of dependency ranges referenced via the `catalog:` protocol. Keys are catalog names and values are object maps of package names to semver ranges.",
+      "type": "object",
+      "patternProperties": {
+        "^\\S+$": {
+          "type": "object",
+          "patternProperties": {
+            "^(?:@([^/]+?)/)?([^/]+?)$": {
+              "type": "string",
+              "pattern": "^(.+)$"
+            }
+          },
+          "additionalProperties": false,
+          "_exampleKeys": [
+            "lodash"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "default": {},
+      "_exampleKeys": [
+        "default"
+      ]
+    },
     "enableColors": {
       "_package": "@yarnpkg/core",
       "title": "Define whether colors are allowed on the standard output.",
       "description": "The default is to check the terminal capabilities, but you can manually override it to either `true` or `false`.",
       "type": "boolean",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "enableConstraintsChecks": {
       "_package": "@yarnpkg/plugin-constraints",
       "title": "Define whether constraints should run on every install.",
       "description": "If true, Yarn will run your constraints right after finishing its installs. This may help decrease the feedback loop delay by catching errors long before your CI would even report them.",
       "type": "boolean",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "enableGlobalCache": {
       "_package": "@yarnpkg/core",
@@ -149,7 +214,9 @@
       "title": "Define whether hyperlinks are allowed on the standard output.",
       "description": "The default is to check the terminal capabilities, but you can manually override it to either `true` or `false`.",
       "type": "boolean",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "enableImmutableCache": {
       "_package": "@yarnpkg/core",
@@ -170,14 +237,18 @@
       "title": "Define whether to print the build output directly within the terminal or not.",
       "description": "If true (the default on CI environments), Yarn will print the build output directly within the terminal instead of buffering it in an external log file. Note that by default Yarn will attempt to use collapsible terminal sequences on supporting CI providers to make the output more legible.",
       "type": "boolean",
-      "examples": [false]
+      "examples": [
+        false
+      ]
     },
     "enableInlineHunks": {
       "_package": "@yarnpkg/plugin-patch",
       "title": "Define whether to print patch hunks directly within the terminal or not.",
       "description": "If true, Yarn will print any patch sections (hunks) that could not be applied successfully to the terminal.",
       "type": "boolean",
-      "examples": [false]
+      "examples": [
+        false
+      ]
     },
     "enableMessageNames": {
       "_package": "@yarnpkg/core",
@@ -212,7 +283,9 @@
       "title": "Define whether animated progress bars should be shown or not.",
       "description": "If true (the default outside of CI environments), Yarn will show progress bars for long-running events.",
       "type": "boolean",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "enableScripts": {
       "_package": "@yarnpkg/core",
@@ -233,7 +306,9 @@
       "title": "Define whether anonymous telemetry data should be sent or not.",
       "description": "If true (the default outside of CI environments), Yarn will periodically send anonymous data to our servers tracking some usage information such as the number of dependencies in your project, how many installs you ran, etc.\n\nConsult the [Telemetry](/advanced/telemetry) page for more details about this process.",
       "type": "boolean",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "enableTimers": {
       "_package": "@yarnpkg/core",
@@ -255,14 +330,18 @@
       "description": "Various files we be stored there: global cache, metadata cache, ...",
       "type": "string",
       "format": "uri-reference",
-      "examples": ["${HOME}/.yarn/berry"]
+      "examples": [
+        "${HOME}/.yarn/berry"
+      ]
     },
     "httpProxy": {
       "_package": "@yarnpkg/core",
       "title": "Proxy to use when making an HTTP request.",
       "type": "string",
       "format": "uri",
-      "examples": ["http://proxy:4040"]
+      "examples": [
+        "http://proxy:4040"
+      ]
     },
     "httpRetry": {
       "_package": "@yarnpkg/core",
@@ -281,28 +360,36 @@
       "title": "Path to a file containing one or multiple Certificate Authority signing certificates.",
       "type": "string",
       "format": "uri-reference",
-      "examples": ["./exampleCA.pem"]
+      "examples": [
+        "./exampleCA.pem"
+      ]
     },
     "httpsCertFilePath": {
       "_package": "@yarnpkg/core",
       "title": "Path to a file containing a certificate chain in PEM format.",
       "type": "string",
       "format": "uri-reference",
-      "examples": ["./exampleCert.pem"]
+      "examples": [
+        "./exampleCert.pem"
+      ]
     },
     "httpsKeyFilePath": {
       "_package": "@yarnpkg/core",
       "title": "Path to a file containing a private key in PEM format.",
       "type": "string",
       "format": "uri-reference",
-      "examples": ["./exampleKey.pem"]
+      "examples": [
+        "./exampleKey.pem"
+      ]
     },
     "httpsProxy": {
       "_package": "@yarnpkg/core",
       "title": "Define a proxy to use when making an HTTPS request.",
       "type": "string",
       "format": "uri",
-      "examples": ["http://proxy:4040"]
+      "examples": [
+        "http://proxy:4040"
+      ]
     },
     "ignorePath": {
       "_package": "@yarnpkg/core",
@@ -319,7 +406,9 @@
         "type": "string"
       },
       "default": [],
-      "_exampleItems": ["**/.pnp.*"]
+      "_exampleItems": [
+        "**/.pnp.*"
+      ]
     },
     "initScope": {
       "_package": "@yarnpkg/plugin-init",
@@ -334,12 +423,20 @@
       "type": "object",
       "patternProperties": {
         "^(.+)$": {
-          "type": ["string", "number", "boolean"],
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ],
           "description": "All properties will be added verbatim to the generated package.json.",
-          "examples": ["https://yarnpkg.com"]
+          "examples": [
+            "https://yarnpkg.com"
+          ]
         }
       },
-      "_exampleKeys": ["homepage"]
+      "_exampleKeys": [
+        "homepage"
+      ]
     },
     "injectEnvironmentFiles": {
       "_package": "@yarnpkg/core",
@@ -351,7 +448,10 @@
         "format": "uri-reference"
       },
       "default": [],
-      "_exampleItems": [".my-env", ".my-local-env?"]
+      "_exampleItems": [
+        ".my-env",
+        ".my-local-env?"
+      ]
     },
     "installStatePath": {
       "_package": "@yarnpkg/core",
@@ -371,24 +471,35 @@
           "code": {
             "type": "string",
             "title": "Match all messages with the given code.",
-            "examples": ["YN0005"]
+            "examples": [
+              "YN0005"
+            ]
           },
           "text": {
             "type": "string",
             "title": "Match messages whose content is strictly equal to the given text.",
             "description": "In case a message matches both `code`-based and `text`-based filters, the `text`-based ones will take precedence over the `code`-based ones.",
-            "examples": ["lorem-ipsum@npm:1.2.3 lists build scripts, but its build has been explicitly disabled through configuration"]
+            "examples": [
+              "lorem-ipsum@npm:1.2.3 lists build scripts, but its build has been explicitly disabled through configuration"
+            ]
           },
           "pattern": {
             "type": "string",
             "title": "Match messages whose content match the given glob pattern.",
             "description": "In case a message matches both `pattern`-based and `code`-based filters, the `pattern`-based ones will take precedence over the other ones. Patterns can be overridden on a case-by-case basis by using the `text` filter, which has precedence over `pattern`.",
-            "examples": ["lorem-ipsum@* lists build scripts, but its build has been explicitly disabled through configuration"]
+            "examples": [
+              "lorem-ipsum@* lists build scripts, but its build has been explicitly disabled through configuration"
+            ]
           },
           "level": {
             "type": "string",
             "title": "New log level to apply to the matching messages. Use `discard` if you wish to hide those messages altogether.",
-            "enum": ["info", "warning", "error", "discard"]
+            "enum": [
+              "info",
+              "warning",
+              "error",
+              "discard"
+            ]
           }
         }
       },
@@ -443,14 +554,20 @@
           }
         }
       },
-      "_exampleKeys": ["*.example.com"]
+      "_exampleKeys": [
+        "*.example.com"
+      ]
     },
     "nmHoistingLimits": {
       "_package": "@yarnpkg/plugin-nm",
       "title": "Highest point where packages can be hoisted.",
       "description": "Replacement of the former `nohoist` setting. Possible values are:\n\n- If `none` (the default), packages are hoisted as per the usual rules.\n- If `workspaces`, packages won't be hoisted past the workspace that depends on them.\n- If `dependencies`, transitive dependencies also won't be hoisted past your direct dependencies.\n\nThis setting can be overridden on a per-workspace basis using the `installConfig.hoistingLimits` field.",
       "type": "string",
-      "enum": ["workspaces", "dependencies", "none"],
+      "enum": [
+        "workspaces",
+        "dependencies",
+        "none"
+      ],
       "default": "none"
     },
     "nmSelfReferences": {
@@ -465,7 +582,11 @@
       "title": "Define how to copy files to their target destination.",
       "description": "Possible values are:\n\n- If `classic`, regular copy or clone operations are performed.\n- If `hardlinks-global`, hardlinks to a global content-addressable store will be used.\n- If `hardlinks-local`, hardlinks will only be created between similar packages from the same project.\n\nFor compatibility with the ecosystem, the default is `classic`.",
       "type": "string",
-      "enum": ["classic", "hardlinks-local", "hardlinks-global"],
+      "enum": [
+        "classic",
+        "hardlinks-local",
+        "hardlinks-global"
+      ],
       "default": "classic"
     },
     "nodeLinker": {
@@ -473,8 +594,16 @@
       "title": "Define how Node packages should be installed.",
       "description": "Yarn supports three ways to install your project's dependencies, based on the `nodeLinker` setting. Possible values are:\n\n- If `pnp`, a single Node.js loader file will be generated.\n- If `pnpm`, a `node-modules` will be created using symlinks and hardlinks to a global content-addressable store.\n- If `node-modules`, a regular `node_modules` folder just like in Yarn Classic or npm will be created.",
       "anyOf": [
-        { "type": "string" },
-        { "enum": ["pnp", "pnpm", "node-modules"] }
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "pnp",
+            "pnpm",
+            "node-modules"
+          ]
+        }
       ],
       "type": "string",
       "default": "pnp"
@@ -485,14 +614,19 @@
       "description": "By default, the store is stored in the `node_modules/.store` of the project. Sometimes in CI scenario's it is convenient to store this in a different location so it can be cached and reused.",
       "type": "string",
       "format": "uri-reference",
-      "examples": [".cache/.store"]
+      "examples": [
+        ".cache/.store"
+      ]
     },
     "winLinkType": {
       "_package": "@yarnpkg/core",
       "title": "Define whether to use junctions or symlinks when creating links on Windows.",
       "description": "Possible values are:\n\n- If `junctions`, Yarn will use Windows junctions when linking workspaces into `node_modules` directories, which are always absolute paths.\n- If `symlinks`, Yarn will use symlinks, which will use relative paths, and is consistent with Yarn's behavior on non-Windows platforms.\n\nSymlinks are preferred, but they require the Windows user running Yarn to have the `create symbolic links` privilege. As a result, we default to using junctions instead.",
       "type": "string",
-      "enum": ["junctions", "symlinks"]
+      "enum": [
+        "junctions",
+        "symlinks"
+      ]
     },
     "npmAlwaysAuth": {
       "_package": "@yarnpkg/plugin-npm",
@@ -507,28 +641,37 @@
       "description": "If not explicitly set, the value of `npmRegistryServer` will be used.",
       "type": "string",
       "format": "uri",
-      "examples": ["https://registry.npmjs.org"]
+      "examples": [
+        "https://registry.npmjs.org"
+      ]
     },
     "npmAuthIdent": {
       "_package": "@yarnpkg/plugin-npm",
       "title": "Define the authentication credentials to use by default when accessing your registries.",
       "description": "Replacement of the former `_auth` setting. Because it requires storing unencrypted values in your configuration, `npmAuthToken` should be preferred when possible.",
       "type": "string",
-      "examples": ["username:password"]
+      "examples": [
+        "username:password"
+      ]
     },
     "npmAuthToken": {
       "_package": "@yarnpkg/plugin-npm",
       "title": "Define the authentication token to use by default when accessing your registries.",
       "description": "Replacement of the former `_authToken` settings. If you're using `npmScopes` to define multiple registries, the `npmRegistries` dictionary allows you to override these credentials on a per-registry basis.",
       "type": "string",
-      "examples": ["ffffffff-ffff-ffff-ffff-ffffffffffff"]
+      "examples": [
+        "ffffffff-ffff-ffff-ffff-ffffffffffff"
+      ]
     },
     "npmPublishAccess": {
       "_package": "@yarnpkg/plugin-npm-cli",
       "type": "string",
       "title": "Define the default access to use when publishing packages to the npm registry.",
       "description": "Valid values are `public` and `restricted`, but `restricted` usually requires to register for a paid plan (this is up to the registry you use). Can be overridden on a per-package basis using the [`publishConfig.access`](manifest#publishConfig.access) field.",
-      "enum": ["public", "restricted"]
+      "enum": [
+        "public",
+        "restricted"
+      ]
     },
     "npmPublishProvenance": {
       "_package": "@yarnpkg/plugin-npm-cli",
@@ -545,7 +688,9 @@
         "type": "string"
       },
       "default": [],
-      "examples": ["known_insecure_package"]
+      "examples": [
+        "known_insecure_package"
+      ]
     },
     "npmAuditIgnoreAdvisories": {
       "_package": "@yarnpkg/plugin-npm-cli",
@@ -555,7 +700,9 @@
         "type": "string"
       },
       "default": [],
-      "examples": ["1234567"]
+      "examples": [
+        "1234567"
+      ]
     },
     "npmPublishRegistry": {
       "_package": "@yarnpkg/plugin-npm",
@@ -563,7 +710,9 @@
       "description": "If not explicitly set, the value of `npmRegistryServer` will be used. Overridden by `publishConfig.registry`.",
       "type": "string",
       "format": "uri",
-      "examples": ["https://npm.pkg.github.com"]
+      "examples": [
+        "https://npm.pkg.github.com"
+      ]
     },
     "npmRegistries": {
       "_package": "@yarnpkg/plugin-npm",
@@ -586,7 +735,9 @@
         }
       },
       "additionalProperties": false,
-      "_exampleKeys": ["//npm.pkg.github.com"]
+      "_exampleKeys": [
+        "//npm.pkg.github.com"
+      ]
     },
     "npmRegistryServer": {
       "_package": "@yarnpkg/plugin-npm",
@@ -606,7 +757,9 @@
           "properties": {
             "npmPublishRegistry": {
               "$ref": "#/properties/npmPublishRegistry",
-              "examples": ["https://registry.yarnpkg.com"]
+              "examples": [
+                "https://registry.yarnpkg.com"
+              ]
             },
             "npmRegistryServer": {
               "$ref": "#/properties/npmRegistryServer"
@@ -624,7 +777,9 @@
         }
       },
       "additionalProperties": false,
-      "_exampleKeys": ["my-company"]
+      "_exampleKeys": [
+        "my-company"
+      ]
     },
     "packageExtensions": {
       "_package": "@yarnpkg/core",
@@ -642,11 +797,15 @@
                 "^(?:@([^/]+?)/)?([^/]+?)$": {
                   "type": "string",
                   "pattern": "^(.+)$",
-                  "examples": ["^4.15.0"]
+                  "examples": [
+                    "^4.15.0"
+                  ]
                 }
               },
               "additionalProperties": false,
-              "_exampleKeys": ["lodash"]
+              "_exampleKeys": [
+                "lodash"
+              ]
             },
             "peerDependencies": {
               "type": "object",
@@ -654,11 +813,15 @@
                 "^(?:@([^/]+?)/)?([^/]+?)$": {
                   "type": "string",
                   "pattern": "^(.+)$",
-                  "examples": ["*"]
+                  "examples": [
+                    "*"
+                  ]
                 }
               },
               "additionalProperties": false,
-              "_exampleKeys": ["webpack-cli"]
+              "_exampleKeys": [
+                "webpack-cli"
+              ]
             },
             "peerDependenciesMeta": {
               "type": "object",
@@ -668,20 +831,26 @@
                   "properties": {
                     "optional": {
                       "type": "boolean",
-                      "examples": [true]
+                      "examples": [
+                        true
+                      ]
                     }
                   }
                 }
               },
               "additionalProperties": false,
-              "_exampleKeys": ["webpack-cli"]
+              "_exampleKeys": [
+                "webpack-cli"
+              ]
             }
           },
           "_margin": false
         }
       },
       "additionalProperties": false,
-      "_exampleKeys": ["webpack@*"]
+      "_exampleKeys": [
+        "webpack@*"
+      ]
     },
     "patchFolder": {
       "_package": "@yarnpkg/plugin-patch",
@@ -709,7 +878,11 @@
       "type": "string",
       "title": "Define whether to allow packages to rely on the builtin PnP fallback mechanism.",
       "description": "Possible values are:\n\n- If `all`, all packages can access dependencies made available in the fallback.\n- If `dependencies-only` (the default), dependencies will have access to them but not your workspaces.\n- If `none`, no packages will have access to them.",
-      "enum": ["none", "dependencies-only", "all"],
+      "enum": [
+        "none",
+        "dependencies-only",
+        "all"
+      ],
       "default": "dependencies-only"
     },
     "pnpIgnorePatterns": {
@@ -721,13 +894,18 @@
         "type": "string"
       },
       "default": [],
-      "_exampleItems": ["./subdir/*"]
+      "_exampleItems": [
+        "./subdir/*"
+      ]
     },
     "pnpMode": {
       "_package": "@yarnpkg/plugin-pnp",
       "title": "Define whether to attempt to simulate traditional `node_modules` hoisting.",
       "description": "Possible values are:\n\n- If `strict` (the default), modules won't be allowed to require packages they don't explicitly list in their own dependencies.\n- If `loose`, packages will be allowed to access any other package that would have been hoisted to the top-level under 1.x installs.\n\nNote that, even in loose mode, hoisted require calls are unsafe and should be discouraged.",
-      "enum": ["strict", "loose"],
+      "enum": [
+        "strict",
+        "loose"
+      ],
       "type": "string",
       "default": "strict"
     },
@@ -778,8 +956,16 @@
       "_package": "@yarnpkg/core",
       "title": "Style of progress bar to use.",
       "type": "string",
-      "enum": ["patrick", "simba", "jack", "hogsfather", "default"],
-      "examples": ["default"]
+      "enum": [
+        "patrick",
+        "simba",
+        "jack",
+        "hogsfather",
+        "default"
+      ],
+      "examples": [
+        "default"
+      ]
     },
     "supportedArchitectures": {
       "_package": "@yarnpkg/core",
@@ -793,7 +979,12 @@
             "type": "string"
           },
           "default": [],
-          "_exampleItems": ["current", "darwin", "linux", "win32"]
+          "_exampleItems": [
+            "current",
+            "darwin",
+            "linux",
+            "win32"
+          ]
         },
         "cpu": {
           "title": "List of CPU architectures to cover.",
@@ -803,7 +994,12 @@
             "type": "string"
           },
           "default": [],
-          "_exampleItems": ["current", "x64", "ia32", "arm64"]
+          "_exampleItems": [
+            "current",
+            "x64",
+            "ia32",
+            "arm64"
+          ]
         },
         "libc": {
           "title": "The list of standard C libraries to cover.",
@@ -812,7 +1008,11 @@
             "type": "string"
           },
           "default": [],
-          "_exampleItems": ["current", "glibc", "musl"]
+          "_exampleItems": [
+            "current",
+            "glibc",
+            "musl"
+          ]
         }
       }
     },
@@ -828,7 +1028,10 @@
       "title": "Execution strategy for heavy tasks.",
       "description": "By default will use workers when performing heavy tasks, such as converting tgz files to zip. This setting can be used to disable workers and use a regular in-thread async processing.",
       "type": "string",
-      "enum": ["async", "workers"],
+      "enum": [
+        "async",
+        "workers"
+      ],
       "default": "workers"
     },
     "telemetryInterval": {
@@ -843,14 +1046,18 @@
       "title": "User-defined unique ID to send along with telemetry events.",
       "description": "The default settings never assign unique IDs to anyone, so we have no way to know which data originates from which project. This setting can be used to force a user ID to be sent to our telemetry server.\n\nFrankly, it's only useful in some very specific use cases. For example, we use it on the Yarn repository in order to exclude our own usage from the public dashboards (since we run Yarn far more often here than anywhere else, the resulting data would be biased).",
       "type": "string",
-      "examples": ["yarnpkg/berry"]
+      "examples": [
+        "yarnpkg/berry"
+      ]
     },
     "tsEnableAutoTypes": {
       "_package": "@yarnpkg/plugin-typescript",
       "title": "Define whether to automatically install @types dependencies.",
       "description": "If true, Yarn will automatically add `@types` dependencies when running `yarn add` with packages that don't provide their own typings (as reported by the Algolia npm database). This behavior is enabled by default if you have a tsconfig.json file at the root of your project, or in your current workspace.",
       "type": "boolean",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "unsafeHttpWhitelist": {
       "_package": "@yarnpkg/core",
@@ -861,7 +1068,10 @@
         "pattern": "[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
       },
       "default": [],
-      "_exampleItems": ["*.example.org", "example.org"]
+      "_exampleItems": [
+        "*.example.org",
+        "example.org"
+      ]
     },
     "virtualFolder": {
       "_package": "@yarnpkg/core",
@@ -878,7 +1088,9 @@
       "description": "This binary will be executed instead of any other (including the global one) for any command run within the directory covered by the rc file. If the file extension ends with `.js` it will be required, and will be spawned in any other case.\n\nThe `yarnPath` setting used to be the preferred way to install Yarn within a project, but we now recommend to use [Corepack](https://nodejs.org/api/corepack.html) in most cases.",
       "type": "string",
       "format": "uri-reference",
-      "examples": ["./scripts/yarn-2.0.0-rc001.js"]
+      "examples": [
+        "./scripts/yarn-2.0.0-rc001.js"
+      ]
     }
   }
 }

--- a/packages/yarnpkg-core/sources/CatalogResolver.ts
+++ b/packages/yarnpkg-core/sources/CatalogResolver.ts
@@ -1,0 +1,69 @@
+import {MessageName}                                     from './MessageName';
+import {ReportError}                                     from './Report';
+import {Resolver, ResolveOptions, MinimalResolveOptions} from './Resolver';
+import * as structUtils                                  from './structUtils';
+import {Descriptor, Locator, Package}                    from './types';
+
+export class CatalogResolver implements Resolver {
+  static protocol = `catalog:`;
+
+  supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {
+    return descriptor.range.startsWith(CatalogResolver.protocol);
+  }
+
+  supportsLocator(locator: Locator, opts: MinimalResolveOptions) {
+    return locator.reference.startsWith(CatalogResolver.protocol);
+  }
+
+  shouldPersistResolution(locator: Locator, opts: MinimalResolveOptions) {
+    return true;
+  }
+
+  bindDescriptor(descriptor: Descriptor, fromLocator: Locator, opts: MinimalResolveOptions) {
+    return descriptor;
+  }
+
+  getResolutionDependencies(descriptor: Descriptor, opts: MinimalResolveOptions) {
+    return {};
+  }
+
+  async getCandidates(descriptor: Descriptor, dependencies: Record<string, Package>, opts: ResolveOptions) {
+    const remainder = descriptor.range.slice(CatalogResolver.protocol.length);
+    const catalogName = remainder.length > 0 ? remainder : `default`;
+
+    const catalogs = opts.project.configuration.get(`dependencyCatalogs`);
+    const catalog = catalogs.get(catalogName);
+    if (!catalog)
+      throw new ReportError(MessageName.CATALOG_NOT_FOUND, `Catalog '${catalogName}' not found`);
+
+    const entry = catalog.get(structUtils.stringifyIdent(descriptor));
+    if (typeof entry === `undefined`)
+      throw new ReportError(MessageName.CATALOG_ENTRY_NOT_FOUND, `Package '${structUtils.stringifyIdent(descriptor)}' not found in catalog '${catalogName}'`);
+
+    const targetDescriptor = opts.project.configuration.normalizeDependency(structUtils.makeDescriptor(descriptor.ident, entry));
+
+    return await opts.resolver.getCandidates(targetDescriptor, dependencies, opts);
+  }
+
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const remainder = descriptor.range.slice(CatalogResolver.protocol.length);
+    const catalogName = remainder.length > 0 ? remainder : `default`;
+
+    const catalogs = opts.project.configuration.get(`dependencyCatalogs`);
+    const catalog = catalogs.get(catalogName);
+    if (!catalog)
+      throw new ReportError(MessageName.CATALOG_NOT_FOUND, `Catalog '${catalogName}' not found`);
+
+    const entry = catalog.get(structUtils.stringifyIdent(descriptor));
+    if (typeof entry === `undefined`)
+      throw new ReportError(MessageName.CATALOG_ENTRY_NOT_FOUND, `Package '${structUtils.stringifyIdent(descriptor)}' not found in catalog '${catalogName}'`);
+
+    const targetDescriptor = opts.project.configuration.normalizeDependency(structUtils.makeDescriptor(descriptor.ident, entry));
+
+    return await opts.resolver.getSatisfying(targetDescriptor, dependencies, locators, opts);
+  }
+
+  async resolve(locator: Locator, opts: ResolveOptions): Promise<Package> {
+    throw new Error(`Expected catalog references to be resolved by underlying resolver`);
+  }
+}

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -32,6 +32,9 @@ import * as semverUtils                                                         
 import * as structUtils                                                                                          from './structUtils';
 import {IdentHash, Package, Descriptor, PackageExtension, PackageExtensionType, PackageExtensionStatus, Locator} from './types';
 
+import {CatalogResolver}
+  from './CatalogResolver';
+
 const isPublicRepository = (function () {
   if (!GITHUB_ACTIONS || !process.env.GITHUB_EVENT_PATH)
     return false;
@@ -628,6 +631,20 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
       },
     },
   },
+
+  dependencyCatalogs: {
+    description: `Map of dependency catalogs used by the \`catalog:\` protocol`,
+    type: SettingsType.MAP,
+    valueDefinition: {
+      description: `The catalog entries`,
+      type: SettingsType.MAP,
+      valueDefinition: {
+        description: `A semver range`,
+        type: SettingsType.STRING,
+      },
+    },
+    default: new Map(),
+  },
 };
 
 export interface ConfigurationValueMap {
@@ -709,6 +726,8 @@ export interface ConfigurationValueMap {
     peerDependencies?: Map<string, string>;
     peerDependenciesMeta?: Map<string, miscUtils.ToMapValue<{optional?: boolean}>>;
   }>>;
+
+  dependencyCatalogs: Map<string, Map<string, string>>;
 }
 
 export type PackageExtensionData = miscUtils.MapValueToObjectValue<miscUtils.MapValue<ConfigurationValueMap[`packageExtensions`]>>;
@@ -1748,6 +1767,7 @@ export class Configuration {
         new VirtualResolver(),
         new WorkspaceResolver(),
 
+        new CatalogResolver(),
         ...pluginResolvers,
       ])
     );

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -103,6 +103,8 @@ export enum MessageName {
   TIPS_NOTICE = 89,
   OFFLINE_MODE_ENABLED = 90,
   INVALID_PROVENANCE_ENVIRONMENT = 91,
+  CATALOG_NOT_FOUND = 92,
+  CATALOG_ENTRY_NOT_FOUND = 93,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -38,6 +38,8 @@ export {ThrowReport}                                                            
 export {VirtualFetcher}                                                                                             from './VirtualFetcher';
 export {WorkspaceFetcher}                                                                                           from './WorkspaceFetcher';
 export {WorkspaceResolver}                                                                                          from './WorkspaceResolver';
+export {CatalogResolver}
+  from './CatalogResolver';
 export {Workspace}                                                                                                  from './Workspace';
 export {YarnVersion}                                                                                                from './YarnVersion';
 export type {IdentHash, DescriptorHash, LocatorHash}                                                                from './types';


### PR DESCRIPTION
## Summary
- add `dependencyCatalogs` setting to config
- implement `catalog:` protocol via `CatalogResolver`
- document catalogs and protocol
- add tests for the new protocol

## Testing
- `yarn test:lint`
- `yarn test:unit`
